### PR TITLE
Fix makefile to use testpypi explicitly (for .pypirc compatibility).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ clean:
 	-rm -r dist
 
 testdeploy: build
-	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+	twine upload --repository testpypi dist/*
 
 deploy: nopost build
 	twine upload dist/*


### PR DESCRIPTION
This change makes `make testdeploy` grab login credentials (API key) from `$HOME/.pypirc`.