### PR TITLE
Fix the destructor ioe device assumption

### DIFF
--- a/inventorhatmini/__init__.py
+++ b/inventorhatmini/__init__.py
@@ -99,6 +99,7 @@ class InventorHATMini():
         """ Initialise inventor hat mini's hardware functions
         """
         self.address = address
+        self.ioe = None
 
         gpiodevice.friendly_errors = True
 
@@ -159,7 +160,8 @@ class InventorHATMini():
         self.ioe.set_mode(self.IOE_CURRENT_SENSES[1], ADC)
 
     def __del__(self):
-        self.ioe.reset()
+        if self.ioe is not None:
+            self.ioe.reset()
 
     def switch_pressed(self):
         return self._read_pin(self._pin_user_sw)


### PR DESCRIPTION
This fixes #13 . 
Ensuring that the member variable ioe exists, but is set to None, means the destructor will not try to dereference the ioe variable it when it hasn't yet been created.